### PR TITLE
Add Umami analytics connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 A template repo to create a [Payload CMS](https://payloadcms.com) plugin.
 
+## Umami Integration
+
+This plugin provides a minimal connection to a self–hosted [Umami](https://umami.is/) instance.
+Add your Umami credentials and URL when installing the plugin so that it can authenticate on `onInit` and expose a basic endpoint.
+
+### Installation
+
+You can install straight from the repository:
+
+```bash
+pnpm add <git url to this repo>
+```
+
+Then enable the plugin in `payload.config.ts`:
+
+```ts
+import { payloadcmsUmami } from 'payloadcms-umami'
+
+export default buildConfig({
+  plugins: [
+    payloadcmsUmami({
+      umamiUrl: 'https://analytics.example.com',
+      username: 'admin',
+      password: 'password',
+      websiteId: 'your-website-id',
+    }),
+  ],
+})
+```
+
+After start up a `/umami-websites` endpoint will proxy the list of websites from your Umami server.
+If you configured `websiteId`, the plugin exposes `/umami-pageviews` which returns the total page views for the last 24 hours and displays them on your dashboard.
+
 Payload is built with a robust infrastructure intended to support Plugins with ease. This provides a simple, modular, and reusable way for developers to extend the core capabilities of Payload.
 
 To build your own Payload plugin, all you need is:

--- a/src/components/AfterDashboardClient.tsx
+++ b/src/components/AfterDashboardClient.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useConfig } from '@payloadcms/ui'
+import { useEffect, useState } from 'react'
+
+export const AfterDashboardClient = () => {
+  const { config } = useConfig()
+  const [pageviews, setPageviews] = useState<number | null>(null)
+
+  useEffect(() => {
+    const fetchPageviews = async () => {
+      try {
+        const res = await fetch(
+          `${config.serverURL}${config.routes.api}/umami-pageviews`,
+        )
+        if (!res.ok) throw new Error('request failed')
+        const data = await res.json()
+        setPageviews(data.pageviews)
+      } catch (err) {
+        console.error('Failed to load pageviews', err)
+      }
+    }
+
+    void fetchPageviews()
+  }, [config])
+
+  return (
+    <div>
+      <h2>Page views last 24 hours: {pageviews ?? 'Loading...'}</h2>
+    </div>
+  )
+}

--- a/src/endpoints/umamiPageviews.ts
+++ b/src/endpoints/umamiPageviews.ts
@@ -1,0 +1,29 @@
+import type { PayloadHandler } from 'payload'
+
+import { getUmamiClient, getUmamiWebsiteId } from '../index.js'
+
+export const umamiPageviewsHandler: PayloadHandler = async () => {
+  const client = getUmamiClient()
+  const websiteId = getUmamiWebsiteId()
+
+  if (!client || !websiteId) {
+    return new Response('Umami not configured', { status: 500 })
+  }
+
+  const endAt = Date.now()
+  const startAt = endAt - 24 * 60 * 60 * 1000
+  const res = await client.fetch(
+    `/api/websites/${websiteId}/metrics?type=pageviews&startAt=${startAt}&endAt=${endAt}`,
+  )
+
+  if (!res.ok) {
+    return new Response('Failed to fetch pageviews', { status: res.status })
+  }
+
+  const data = await res.json()
+
+  // The API returns { pageviews: number } or { metrics: [...] }, depend on version
+  const pageviews = data?.pageviews ?? data?.metrics?.reduce((sum: number, m: any) => sum + Number(m.y), 0)
+
+  return Response.json({ pageviews })
+}

--- a/src/endpoints/umamiWebsites.ts
+++ b/src/endpoints/umamiWebsites.ts
@@ -1,0 +1,14 @@
+import type { PayloadHandler } from 'payload'
+
+import { getUmamiClient } from '../index.js'
+
+export const umamiWebsitesHandler: PayloadHandler = async () => {
+  const client = getUmamiClient()
+  if (!client) {
+    return new Response('Umami not configured', { status: 500 })
+  }
+
+  const res = await client.fetch('/api/websites')
+  const data = await res.json()
+  return Response.json(data)
+}

--- a/src/exports/client.ts
+++ b/src/exports/client.ts
@@ -1,1 +1,2 @@
 export { BeforeDashboardClient } from '../components/BeforeDashboardClient.js'
+export { AfterDashboardClient } from '../components/AfterDashboardClient.js'

--- a/src/utils/umamiClient.ts
+++ b/src/utils/umamiClient.ts
@@ -1,0 +1,43 @@
+export type LoginResponse = {
+  token: string
+}
+
+export class UmamiClient {
+  private token: null | string = null
+  constructor(
+    private url: string,
+    private username: string,
+    private password: string,
+  ) {}
+
+  async fetch(path: string, init?: RequestInit): Promise<Response> {
+    if (!this.token) {
+      throw new Error('Umami client not authenticated')
+    }
+
+    const headers = new Headers(init?.headers)
+    headers.set('Authorization', `Bearer ${this.token}`)
+
+    return fetch(`${this.url}${path}`, {
+      ...init,
+      headers,
+    })
+  }
+
+  async login(): Promise<void> {
+    const res = await fetch(`${this.url}/api/auth/login`, {
+      body: JSON.stringify({ password: this.password, username: this.username }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'post',
+    })
+
+    if (!res.ok) {
+      throw new Error(`Umami login failed: ${res.status}`)
+    }
+
+    const data: LoginResponse = await res.json()
+    this.token = data.token
+  }
+}


### PR DESCRIPTION
## Summary
- add basic README usage for Umami
- implement Umami client with login
- expose `/umami-websites` endpoint
- authenticate to Umami on init
- allow selecting a website via `websiteId`
- expose `/umami-pageviews` endpoint and dashboard widget

## Testing
- `pnpm lint` *(fails: Cannot find package '@payloadcms/eslint-config')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5f3aa0b8832c8d4ce0301ca53149